### PR TITLE
Fixed wrong composer/runtime-api dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=8.0 <8.5",
-        "composer/runtime-api": "^2.0",
+        "composer-runtime-api": "^2.0",
         "magento-hackathon/magento-composer-installer": "*",
         "spatie/ignition": "^1.15.1"
     },


### PR DESCRIPTION
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires empiricompany/openmage_ignition ^1.5 -> satisfiable by empiricompany/openmage_ignition[1.5.0].
    - empiricompany/openmage_ignition 1.5.0 requires composer/runtime-api ^2.0 -> could not be found in any version, there may be a typo in the package name.
```