### PR TITLE
Update PHP version constraint to <8.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
       "openmage"
     ],
     "require": {
-        "php": ">=8.0 <8.5",
+        "php": ">=8.0 <8.6",
         "composer-runtime-api": "^2.0",
         "magento-hackathon/magento-composer-installer": "*",
         "spatie/ignition": "^1.15.1"


### PR DESCRIPTION
Ensure Openmage can get installed on php 8.5. Maybe we should use constraint `"php": "^8.0"` like seen in the `spatie/ignition` package to prevent future headache when php updates again.